### PR TITLE
Fix an issue when a super admin user connects a Google Classroom

### DIFF
--- a/app/controllers/orgs/google_classroom_configurations_controller.rb
+++ b/app/controllers/orgs/google_classroom_configurations_controller.rb
@@ -70,7 +70,7 @@ module Orgs
       next_page = nil
       courses = []
       loop do
-        response = @google_classroom_service.list_courses(course_states: "ACTIVE", page_size: 20, page_token: next_page)
+        response = @google_classroom_service.list_courses(course_states: "ACTIVE", teacher_id: "me", page_size: 20, page_token: next_page)
 
         courses.push(*response.courses)
 


### PR DESCRIPTION
If a G Suite Super Admin lists courses from Google Classroom, all courses on the domain are returned. When there are many courses, the request times out.

Adding teacher_id: "me" to the request fixes this error for G Suite Super Admins
